### PR TITLE
Don't call store_factory to avoid NoneType error

### DIFF
--- a/flask_openid.py
+++ b/flask_openid.py
@@ -502,7 +502,7 @@ class OpenID(object):
         def decorated(*args, **kwargs):
             if request.args.get('openid_complete') != u'yes':
                 return f(*args, **kwargs)
-            consumer = Consumer(SessionWrapper(self), self.store_factory())
+            consumer = Consumer(SessionWrapper(self), self.store_factory)
             args = request.args.to_dict()
             args.update(request.form.to_dict())
             openid_response = consumer.complete(args, self.get_current_url())
@@ -561,7 +561,7 @@ class OpenID(object):
                     if key not in ALL_KEYS:
                         raise ValueError('invalid optional key %r' % key)
         try:
-            consumer = Consumer(SessionWrapper(self), self.store_factory())
+            consumer = Consumer(SessionWrapper(self), self.store_factory)
             auth_request = consumer.begin(identity_url)
             if ask_for or ask_for_optional:
                 self.attach_reg_info(auth_request, ask_for, ask_for_optional)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ else:
 
 setup(
     name='Flask-OpenID-Stateless',
-    version='1.2.5',
+    version='1.2.6',
     url='http://github.com/canonical-webteam/flask-openid/',
     license='BSD',
     author='Canonical Web Team',


### PR DESCRIPTION
I don't know why this wasn't added when I created the first PR

This fixes a NoneType error if the porject is stateless